### PR TITLE
[#28] feat: property naming strategy를 snake case로 변경

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,7 +1,7 @@
 spring:
-    devtools:
-        livereload:
-            enabled: true
+    output:
+        ansi:
+            enabled: always
     datasource:
         driver-class-name: org.postgresql.Driver
         url: ENC(327bqzDUVQ4LBzAkxyZd2Tpq+Qj3eWLQeZmzKxVVika5FIPSiJSsBD4geSskSLurPsQg9sz4r87S4BLax0Q8ig==)
@@ -23,6 +23,8 @@ spring:
                 show_sql: true
                 format_sql: true
                 use_sql_comments: true
+    jackson:
+        property-naming-strategy: SNAKE_CASE
 
 cloud:
    aws:
@@ -42,8 +44,8 @@ logging:
             amazonaws:
                 util:
                     EC2MetadataUtils: error
-        org:
-            hibernate:
-                type:
-                    descriptor:
-                        sql: trace
+#        org:
+#            hibernate:
+#                type:
+#                    descriptor:
+#                        sql: trace


### PR DESCRIPTION
1. output.ansi.enabled=always
   - console log에 색 입혀짐
2. jackson.property-naming-strategy=SNAKE_CASE
   - Jackson Library가 해당 설정을 읽어서 JSON으로 변환 시 property들을 해당하는 naming strategy로 변환함

Closes #28